### PR TITLE
Blesk code refactoring and misc bug fixes

### DIFF
--- a/root/static/js/blesk.js
+++ b/root/static/js/blesk.js
@@ -1,44 +1,29 @@
 "use strict";
-// wrapping everything into one function - so that nothing is polluting the rest of js code
-document.addEventListener('DOMContentLoaded', function () {
-    // setValue - getValue - functions to store and retrieve notifications text (using localStorage instead of cookies)
-    // showNotifications() process the notifcations and place it on the page
-    // loadData() load the current notifications
-    // addLoadEvent() - programming onload function
 
+// wrapping everything into one function - so that nothing is polluting the rest of js code
+(function () {
+
+    var server = "http://blesk",
+        appId = "default",
+        notifications = [],
+        processedGUIDsHash = {},
+        targetElement,
+        targetElementInnerHtml;
+
+    // stores key/value in local storage
     function setValue(key, value) {
         if (window.localStorage) {
             localStorage.setItem(key, value);
         }
     }
 
+    // retrives value given a key from local storage
     function getValue(key) {
         if (window.localStorage) {
             return localStorage.getItem(key);
         }
         return null;
     }
-
-    var server = "http://blesk",
-        appId = "default",
-        targetElement,
-        firstAfterBody,
-        targetElementInnerHtml,
-        stylesheet,
-        showNotification,
-        loadData;
-
-    if (document.getElementById("blesk")) {
-        targetElement = document.getElementById("blesk");
-        appId = targetElement.getAttribute("data-appid") || "appId";
-        server = targetElement.getAttribute("data-server") || server;
-    } else {
-        firstAfterBody = document.createElement("div");
-        document.body.insertBefore(firstAfterBody, document.body.firstChild);
-        targetElement = firstAfterBody;
-    }
-
-    targetElementInnerHtml = targetElement.innerHTML;
 
     function addCSSRule(sheet, selector, rules, index) {
         if (sheet.insertRule) {
@@ -48,8 +33,116 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     }
 
-    stylesheet = (function() {
-        var style = document.createElement("style");
+    // fetches current notifications
+    function loadData() {
+        var req = new XMLHttpRequest();
+        req.open("GET", server + "/getAllNotificationsCached?time=" + Math.random(), true);
+        req.onload = function () {
+            showNotification(JSON.parse(req.responseText));
+        };
+        req.send();
+    }
+
+    function createNotification(data) {
+
+        var notification,
+            notificationTextContainer,
+            close;
+
+        notification = {
+            message: data.message,
+            type: data.alertType,
+            localStorageKey: "blesk:" + data.key
+        };
+
+        //creating DOM/Node
+        notificationTextContainer = document.createElement("div");
+        notificationTextContainer.id = "notification-div";
+        notificationTextContainer.innerHTML = "<div class=\"bleskInner\"><strong>" + notification.type + ": </strong>" + notification.message + "</div>";
+        notificationTextContainer.className = "bleskInner";
+        close = document.createElement("div");
+        close.className = "bleskClose";
+        close.innerHTML = "&times;";
+        notificationTextContainer.appendChild(close);
+
+        notification.close = close;
+        notification.node = notificationTextContainer;
+
+        notifications.push(notification);
+
+    }
+
+    function processNotifications(data) {
+
+        var currentNotice;
+
+        data.forEach(function (noticeJSON) {
+
+            currentNotice = noticeJSON[1];
+
+            if (!processedGUIDsHash[currentNotice.key] && //if GUID has not been already processed
+                (currentNotice.appId === appId || currentNotice.appId === "all")) { //if notification is relevant for current app
+                createNotification(currentNotice);
+            }
+
+            processedGUIDsHash[currentNotice.key] = true;
+        });
+
+    }
+
+    function displayRelevantNotifications() {
+
+        var localStorageKey,
+            notificationContainer,
+            notification;
+
+        while (notifications.length) {
+
+            notification = notifications.shift();
+
+            localStorageKey = notification.localStorageKey;
+
+            if (!getValue(localStorageKey)) {
+
+                notificationContainer = document.createElement('div');
+                notificationContainer.localStorageKey = localStorageKey;
+                notificationContainer.classList.add('bleskOuter');
+                notificationContainer.appendChild(notification.node);
+                targetElement.appendChild(notificationContainer);
+
+                notification.close.addEventListener("click", function () {
+
+                    var container = this.parentNode.parentNode;
+
+                    setValue(container.localStorageKey, true);
+
+                    container.parentNode.removeChild(container);
+
+                });
+
+            }
+
+        }
+
+        // closing float
+        targetElement.insertAdjacentHTML('beforeend', "<div style=\"clear:both\"></div>" + targetElementInnerHtml);
+
+    }
+
+    function showNotification(data) {
+
+        processNotifications(data);
+        displayRelevantNotifications();
+
+        // Regularly pulling for data
+        setTimeout(loadData, 10000);
+
+    }
+
+    function setStyle() {
+
+        var style = document.createElement("style"),
+            stylesheet;
 
         // WebKit hack :(
         style.appendChild(document.createTextNode(""));
@@ -57,91 +150,41 @@ document.addEventListener('DOMContentLoaded', function () {
         // Add the <style> element to the page
         document.body.appendChild(style);
 
-        return style.sheet;
-    })();
+        stylesheet = style.sheet;
 
-    addCSSRule(stylesheet, ".bleskOuter", "background-color: #DFF0D8; border-radius: 4px; border: 1px solid #D6E9C6; color: #468847; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 20px; padding: 8px 0 8px 14px; text-shadow: rgba(255, 255, 255, 0.498039) 0 1px 0; margin-bottom: 10px;");
-    addCSSRule(stylesheet, ".bleskInner", "max-width: 94%; display: inline-block; min-width: 94%; padding-right: 2%;");
-    addCSSRule(stylesheet, ".bleskClose", "display: inline-block; right: 20px; vertical-align: top; cursor: pointer; text-align: right; font-size: 26px; font-weight: bold; line-height: 0.6em;");
+        addCSSRule(stylesheet, ".bleskOuter", "background-color: #DFF0D8; border-radius: 4px; border: 1px solid #D6E9C6; color: #468847; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 20px; padding: 8px 0 8px 14px; text-shadow: rgba(255, 255, 255, 0.498039) 0 1px 0; margin-bottom: 10px;");
+        addCSSRule(stylesheet, ".bleskInner", "max-width: 94%; display: inline-block; min-width: 94%; padding-right: 2%;");
+        addCSSRule(stylesheet, ".bleskClose", "display: inline-block; right: 20px; vertical-align: top; cursor: pointer; text-align: right; font-size: 26px; font-weight: bold; line-height: 0.6em;");
 
-    // Create show notification data handler
-    showNotification = function(data) {
+    }
 
-        var obj,
-            notificationText = "",
-            notificationType = "",
-            globalNotificationText = "",
-            globalNotificationType = "",
-            i,
-            notificationTextContainer,
-            close;
+    function createTargetElementIfRequired() {
 
-        //console.log(data);
-        for (i = 0; i < data.length; i++) {
-            //console.log(data[i][1].appId);
-            if (data[i][1].appId === appId) {
-                notificationText = data[i][1].message + " ";
-                notificationType = data[i][1].alertType;
-            }
+        var firstAfterBody;
 
-            if (data[i][1].appId === "all") {
-                globalNotificationText = data[i][1].message + " ";
-                globalNotificationType = data[i][1].alertType;
-            }
+        targetElement = document.getElementById("blesk");
+
+        if (!targetElement) {
+            firstAfterBody = document.createElement("div");
+            document.body.insertBefore(firstAfterBody, document.body.firstChild);
+            targetElement = firstAfterBody;
         }
 
-        if (globalNotificationText) {
-            if (notificationText) {
-                notificationText = globalNotificationText + " | <strong>" + notificationType + ":</strong> " + notificationText;
-            } else {
-                notificationText = globalNotificationText;
-            }
-            notificationType = globalNotificationType;
-        }
+    }
 
-        if (notificationText.length > 0) {
-            notificationTextContainer = document.createElement("div");
-            notificationTextContainer.id = "notification-div";
-            notificationTextContainer.innerHTML = "<div class=\"bleskInner\"><strong>" + notificationType + ": </strong>" + notificationText + "</div>";
-            notificationTextContainer.className = "bleskInner";
-            close = document.createElement("div");
-            close.className = "bleskClose";
-            close.innerHTML = "&times;";
-            close.id = "bleskClose";
-            notificationTextContainer.appendChild(close);
-            if (notificationText.length > 0) {
-                //alert(getValue("blesknotifications"));
-                if ((!getValue("blesknotifications" + appId)) || (notificationText !== getValue("blesknotifications" + appId))) {
+    function populateVariables() {
+        appId = targetElement.getAttribute("data-appid") || "appId";
+        server = targetElement.getAttribute("data-server") || server;
+        targetElementInnerHtml = targetElement.innerHTML;
+    }
 
-                    targetElement.innerHTML = "<div id=\"bleskOuter\" class=\"bleskOuter\">" + notificationTextContainer.innerHTML + "</div><div style=\"clear:both\"></div>" + targetElementInnerHtml;
-                    document.getElementById("bleskClose").addEventListener("click", function () {
-                        document.getElementById("blesk").style.display = "none";
-                        setValue("blesknotifications" + appId, notificationText);
-                    });
+    function init() {
+        setStyle();
+        createTargetElementIfRequired();
+        populateVariables();
+        loadData();
+    }
 
-                } else {
-                    // closing float
-                    targetElement.innerHTML = "<div style=\"clear:both\"></div>" + targetElementInnerHtml;
-                }
-            } else {
-                // closing float
-                targetElement.innerHTML = "<div style=\"clear:both\"></div>" + targetElementInnerHtml;
-            }
+    init();
 
-        } else {
-            targetElement.innerHTML = "";
-        }
-        setTimeout(loadData, 10000);
-    };
-
-    // Regularly pulling for data
-    loadData = function () {
-        var req = new XMLHttpRequest();
-        req.open("GET", server + "/getAllNotificationsCached?time=" + Math.random(), true);
-        req.onload = function () {
-            showNotification(JSON.parse(req.responseText));
-        };
-        req.send();
-    };
-    loadData();
-});
+}());

--- a/root/static/js/usage-default.html
+++ b/root/static/js/usage-default.html
@@ -3,6 +3,6 @@
 </head>
 <body>
 <div id="blesk" data-appid="bleskdemo" data-server="http://notifications.test.netflix.net"></div>
-<script type="text/javascript" src="./blesk.js"></script>
+<script async type="text/javascript" src="./blesk.js"></script>
 </body>
 </html>

--- a/root/static/js/usage-overrides.html
+++ b/root/static/js/usage-overrides.html
@@ -35,6 +35,6 @@
 </head>
 <body>
 <div id="blesk" data-appid="bleskdemo" data-server="http://notifications.test.netflix.net"></div>
-<script type="text/javascript" src="blesk.js"></script>
+<script async type="text/javascript" src="blesk.js"></script>
 </body>
 </html>


### PR DESCRIPTION
I attempted to keep the current coding style/patterns whenever possible, and only refactored what was required in order to fix bugs. 

**Bug Fixes**:
- If two or more notifications are scheduled only the latest one is displayed
- If a notification contains the exact text of a previously 'accepted/closed'  notification it won't be displayed 

**Behaviour modifications**:
- When an "all" notification is accepted is not displayed anymore/anywhere (currently the user needs to  'accept/close' the notification for each appID)
- If an "all" notification is scheduled simultaneously with a 'standard' notification it no longer compresses them into a single notification instead there will be two notification instances
- Adding 'asyc' attribute so browser understand that Blesk script is decoupled from the rest of the app (and thus does not block) 

**TODO but out of refactoring scope**:
- All notification are displayed in green regardless of type (alerts should be red-ish perhaps?)
- There has been no thought put into the localstorage lifecycle, we should purge 'accepted/closed' notification once they have expired
